### PR TITLE
Enable/disable webworker test depending on JSEnv

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,10 +66,10 @@ ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("${{ matrix.ci }}")
 
 replaceCommandAlias("ci", ciVariants.mkString("; ", "; ", ""))
 
-addCommandAlias("ciNode", "; set useJSEnv := JSEnv.NodeJS; test; core/doc")
-addCommandAlias("ciFirefox", "; set useJSEnv := JSEnv.Firefox; test; set useJSEnv := JSEnv.NodeJS")
-addCommandAlias("ciChrome", "; set useJSEnv := JSEnv.Chrome; test; set useJSEnv := JSEnv.NodeJS")
-addCommandAlias("ciJSDOMNodeJS", "; set useJSEnv := JSEnv.JSDOMNodeJS; test; set useJSEnv := JSEnv.NodeJS")
+addCommandAlias("ciNode", "; set Global / useJSEnv := JSEnv.NodeJS; test; core/doc")
+addCommandAlias("ciFirefox", "; set Global / useJSEnv := JSEnv.Firefox; test; set Global / useJSEnv := JSEnv.NodeJS")
+addCommandAlias("ciChrome", "; set Global / useJSEnv := JSEnv.Chrome; test; set Global / useJSEnv := JSEnv.NodeJS")
+addCommandAlias("ciJSDOMNodeJS", "; set Global / useJSEnv := JSEnv.JSDOMNodeJS; test; set Global / useJSEnv := JSEnv.NodeJS")
 
 // release configuration
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,10 +66,10 @@ ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("${{ matrix.ci }}")
 
 replaceCommandAlias("ci", ciVariants.mkString("; ", "; ", ""))
 
-addCommandAlias("ciNode", "; set useJSEnv := JSEnv.NodeJS; core/test; core/doc")
-addCommandAlias("ciFirefox", "; set useJSEnv := JSEnv.Firefox; all core/test webworker/test; set useJSEnv := JSEnv.NodeJS")
-addCommandAlias("ciChrome", "; set useJSEnv := JSEnv.Chrome; all core/test webworker/test; set useJSEnv := JSEnv.NodeJS")
-addCommandAlias("ciJSDOMNodeJS", "; set useJSEnv := JSEnv.JSDOMNodeJS; core/test; set useJSEnv := JSEnv.NodeJS")
+addCommandAlias("ciNode", "; set useJSEnv := JSEnv.NodeJS; test; core/doc")
+addCommandAlias("ciFirefox", "; set useJSEnv := JSEnv.Firefox; test; set useJSEnv := JSEnv.NodeJS")
+addCommandAlias("ciChrome", "; set useJSEnv := JSEnv.Chrome; test; set useJSEnv := JSEnv.NodeJS")
+addCommandAlias("ciJSDOMNodeJS", "; set useJSEnv := JSEnv.JSDOMNodeJS; test; set useJSEnv := JSEnv.NodeJS")
 
 // release configuration
 
@@ -161,6 +161,6 @@ lazy val webworker = project
       "org.scalameta" %%% "munit" % MUnitVersion % Test,
     ),
     (Test / test) := (Test / test).dependsOn(Compile / fastOptJS).value,
-    buildInfoKeys := Seq(scalaVersion, baseDirectory, BuildInfoKey("jsEnv" -> useJSEnv.value.toString)),
+    buildInfoKeys := Seq(scalaVersion, baseDirectory, BuildInfoKey("isBrowser" -> useJSEnv.value.isBrowser)),
     buildInfoPackage := "org.scalajs.macrotaskexecutor")
   .enablePlugins(ScalaJSPlugin, BuildInfoPlugin, NoPublishPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -161,6 +161,6 @@ lazy val webworker = project
       "org.scalameta" %%% "munit" % MUnitVersion % Test,
     ),
     (Test / test) := (Test / test).dependsOn(Compile / fastOptJS).value,
-    buildInfoKeys := Seq[BuildInfoKey](scalaVersion, baseDirectory),
+    buildInfoKeys := Seq(scalaVersion, baseDirectory, BuildInfoKey("jsEnv" -> useJSEnv.value.toString)),
     buildInfoPackage := "org.scalajs.macrotaskexecutor")
   .enablePlugins(ScalaJSPlugin, BuildInfoPlugin, NoPublishPlugin)

--- a/project/JSEnv.scala
+++ b/project/JSEnv.scala
@@ -1,7 +1,7 @@
-sealed abstract class JSEnv
+sealed abstract class JSEnv(val isBrowser: Boolean)
 object JSEnv {
-  case object Chrome extends JSEnv
-  case object Firefox extends JSEnv
-  case object JSDOMNodeJS extends JSEnv
-  case object NodeJS extends JSEnv
+  case object Chrome extends JSEnv(true)
+  case object Firefox extends JSEnv(true)
+  case object JSDOMNodeJS extends JSEnv(false)
+  case object NodeJS extends JSEnv(false)
 }

--- a/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
+++ b/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
@@ -20,8 +20,6 @@ import munit.FunSuite
 import org.scalajs.dom.webworkers.Worker
 
 import scala.concurrent.Promise
-import scala.scalajs.js
-import scala.util.Try
 
 class WebWorkerMacrotaskSuite extends FunSuite {
 

--- a/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
+++ b/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
@@ -28,32 +28,29 @@ class WebWorkerMacrotaskSuite extends FunSuite {
   import MacrotaskExecutor.Implicits._
 
   def scalaVersion = if (BuildInfo.scalaVersion.startsWith("2"))
-    BuildInfo.scalaVersion.split("\\.").init.mkString(".")
+    BuildInfo.scalaVersion.split('.').init.mkString(".")
   else
     BuildInfo.scalaVersion
 
   def targetDir = s"${BuildInfo.baseDirectory}/target/scala-${scalaVersion}"
 
-  Try(js.isUndefined(js.Dynamic.global.window.Worker)).toOption
-    .filterNot(identity)
-    .foreach { _ =>
-      test("pass the MacrotaskSuite in a web worker") {
-        val p = Promise[Boolean]()
+  test("pass the MacrotaskSuite in a web worker") {
+    val p = Promise[Boolean]()
 
-        val worker = new Worker(
-          s"file://${targetDir}/scala-js-macrotask-executor-webworker-fastopt/main.js"
-        )
+    val worker = new Worker(
+      s"file://${targetDir}/scala-js-macrotask-executor-webworker-fastopt/main.js"
+    )
 
-        worker.onmessage = { event =>
-          event.data match {
-            case log: String      => println(log)
-            case success: Boolean => p.success(success)
-            case _                => ()
-          }
-        }
-
-        p.future.map(assert(_))
-
+    worker.onmessage = { event =>
+      event.data match {
+        case log: String      => println(log)
+        case success: Boolean => p.success(success)
+        case _                => ()
       }
     }
+
+    p.future.map(assert(_))
+
+  }
+
 }

--- a/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
+++ b/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
@@ -32,10 +32,7 @@ class WebWorkerMacrotaskSuite extends FunSuite {
 
   def targetDir = s"${BuildInfo.baseDirectory}/target/scala-${scalaVersion}"
 
-  override def munitIgnore = {
-    println(BuildInfo)
-    !BuildInfo.isBrowser
-  }
+  override def munitIgnore = !BuildInfo.isBrowser
 
   test("pass the MacrotaskSuite in a web worker") {
     val p = Promise[Boolean]()

--- a/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
+++ b/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
@@ -32,6 +32,8 @@ class WebWorkerMacrotaskSuite extends FunSuite {
 
   def targetDir = s"${BuildInfo.baseDirectory}/target/scala-${scalaVersion}"
 
+  override def munitIgnore = !Set("Firefox", "Chrome").contains(BuildInfo.jsEnv)
+
   test("pass the MacrotaskSuite in a web worker") {
     val p = Promise[Boolean]()
 

--- a/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
+++ b/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
@@ -32,7 +32,7 @@ class WebWorkerMacrotaskSuite extends FunSuite {
 
   def targetDir = s"${BuildInfo.baseDirectory}/target/scala-${scalaVersion}"
 
-  override def munitIgnore = !Set("Firefox", "Chrome").contains(BuildInfo.jsEnv)
+  override def munitIgnore = !BuildInfo.isBrowser
 
   test("pass the MacrotaskSuite in a web worker") {
     val p = Promise[Boolean]()

--- a/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
+++ b/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskSuite.scala
@@ -32,7 +32,10 @@ class WebWorkerMacrotaskSuite extends FunSuite {
 
   def targetDir = s"${BuildInfo.baseDirectory}/target/scala-${scalaVersion}"
 
-  override def munitIgnore = !BuildInfo.isBrowser
+  override def munitIgnore = {
+    println(BuildInfo)
+    !BuildInfo.isBrowser
+  }
 
   test("pass the MacrotaskSuite in a web worker") {
     val p = Promise[Boolean]()


### PR DESCRIPTION
Since in CI we're only running the webworker tests in the appropriate environment anyway, we don't need this programmatic check for webworker support to decide whether to enable/disable the test. Instead, better the test fails rather than be silently ignored.

OTOH, this would break `root/test`. Thoughts?