### PR TITLE
Expose the `setImmediate` polyfill so that libraries can use it directly

### DIFF
--- a/core/src/main/scala/org/scalajs/macrotaskexecutor/MacrotaskExecutor.scala
+++ b/core/src/main/scala/org/scalajs/macrotaskexecutor/MacrotaskExecutor.scala
@@ -34,7 +34,7 @@ object MacrotaskExecutor extends ExecutionContextExecutor {
   def reportFailure(cause: Throwable): Unit =
     cause.printStackTrace()
 
-  private[this] val setImmediate: (() => Unit) => Unit = {
+  val setImmediate: (() => Unit) => Unit = {
     if (js.typeOf(js.Dynamic.global.setImmediate) == Undefined) {
       var nextHandle = 1
       val tasksByHandle = mutable.Map[Int, () => Unit]()


### PR DESCRIPTION
I have a bunch of `setTimeout(..., 0)` calls in scalajs-react and I'd like to replace them using this `setImmediate` polyfill.