### PR TITLE
Remove scala-js-dom dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,9 +155,6 @@ lazy val webworker = project
   .settings(
     name := "scala-js-macrotask-executor-webworker",
     scalaJSUseMainModuleInitializer := true,
-    libraryDependencies ++= Seq(
-      "org.scala-js" %%% "scalajs-dom" % "2.0.0",
-    ),
     (Test / test) := {
       if (useJSEnv.value.isBrowser)
         (Test / test).dependsOn(Compile / fastOptJS).value

--- a/webworker/src/main/scala/org/scalajs/macrotaskexecutor/MacrotaskExecutorTestsRunner.scala
+++ b/webworker/src/main/scala/org/scalajs/macrotaskexecutor/MacrotaskExecutorTestsRunner.scala
@@ -16,8 +16,6 @@
 
 package org.scalajs.macrotaskexecutor
 
-import org.scalajs.dom.DedicatedWorkerGlobalScope
-
 import scala.scalajs.concurrent.QueueExecutionContext.timeouts
 import scala.scalajs.js
 
@@ -32,7 +30,7 @@ object MacrotaskExecutorTestsRunner {
       clamping <- tests.`sequence a series of 10,000 recursive executions without clamping`
       fairness <- tests.`preserve fairness with setTimeout`
       parallel <- tests.`execute a bunch of stuff in 'parallel' and ensure it all runs`
-    } yield DedicatedWorkerGlobalScope.self.postMessage(js.Dictionary(
+    } yield js.Dynamic.global.postMessage(js.Dictionary(
       "clamping" -> clamping.isSuccess,
       "fairness" -> fairness.isSuccess,
       "parallel" -> parallel.isSuccess

--- a/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskTests.scala
+++ b/webworker/src/test/scala/org/scalajs/macrotaskexecutor/WebWorkerMacrotaskTests.scala
@@ -17,8 +17,6 @@
 package org.scalajs.macrotaskexecutor
 
 import org.junit.Test
-import org.scalajs.dom.MessageEvent
-import org.scalajs.dom.Worker
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -33,10 +31,11 @@ class WebWorkerMacrotaskTests {
 
   implicit val ec: ExecutionContext = timeouts()
 
-  val worker = new Worker(s"file://${BuildInfo.workerDir}/main.js")
+  val worker =
+    js.Dynamic.newInstance(js.Dynamic.global.Worker)(s"file://${BuildInfo.workerDir}/main.js")
 
   val testsResult = Promise[js.Dictionary[Boolean]]()
-  worker.onmessage = { (event: MessageEvent) =>
+  worker.onmessage = { (event: js.Dynamic) =>
     testsResult.success(event.data.asInstanceOf[js.Dictionary[Boolean]])
   }
 


### PR DESCRIPTION
And thus, we no longer have any dependencies except Scala.js core and the JSEnvs.