### PR TITLE
Update to Scala 3.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.11.12, 2.12.15, 2.13.7, 3.0.2]
+        scala: [2.11.12, 2.12.15, 2.13.7, 3.1.3]
         java: [temurin@11]
         ci: [ciNode, ciFirefox, ciChrome, ciJSDOMNodeJS]
     runs-on: ${{ matrix.os }}
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.2]
+        scala: [3.1.3]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ import org.scalajs.jsenv.selenium.SeleniumJSEnv
 
 import java.util.concurrent.TimeUnit
 
-ThisBuild / baseVersion := "1.0"
+ThisBuild / baseVersion := "1.1"
 
 ThisBuild / organization := "org.scala-js"
 ThisBuild / organizationName := "Scala.js (https://www.scala-js.org/)"
@@ -42,7 +42,7 @@ ThisBuild / scmInfo := Some(
 
 // build and matrix configuration
 
-ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.15", "2.13.7", "3.0.2")
+ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.15", "2.13.7", "3.1.3")
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Use(


### PR DESCRIPTION
This update includes https://github.com/lampepfl/dotty/pull/14318. The bug it fixes seems to cause all sorts of problems when trying to do things with sourcemaps.

While we're here, should we update our other Scala versions?