### PR TITLE
Migrate build to sbt-typelevel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,18 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['**']
+    branches: ['**', '!update/**', '!pr/**']
   push:
-    branches: ['**']
+    branches: ['**', '!update/**', '!pr/**']
     tags: [v*]
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
   SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
   PGP_SECRET: ${{ secrets.PGP_SECRET }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -27,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.11.12, 2.12.15, 2.13.7, 3.1.3]
-        java: [temurin@11]
+        java: [temurin@8]
         ci: [ciNode, ciFirefox, ciChrome, ciJSDOMNodeJS]
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,12 +38,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v1
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v2
+        with:
+          distribution: jdkfile
+          java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -67,19 +78,19 @@ jobs:
         run: npm install
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
 
-      - run: sbt ++${{ matrix.scala }} '${{ matrix.ci }}'
+      - run: sbt '++${{ matrix.scala }}' '${{ matrix.ci }}'
 
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-latest]
         scala: [3.1.3]
-        java: [temurin@11]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -87,12 +98,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v1
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v2
+        with:
+          distribution: jdkfile
+          java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -107,15 +127,15 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Import signing key
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
+        run: echo $PGP_SECRET | base64 -di | gpg --import
+
+      - name: Import signing key and strip passphrase
+        if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE != ''
         run: |
-          echo "$PGP_SECRET" | base64 -d > /tmp/signing-key.gpg
+          echo "$PGP_SECRET" | base64 -di > /tmp/signing-key.gpg
           echo "$PGP_PASSPHRASE" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg
+          (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
-      - name: Strip passphrase from signing key
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        run: (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase 5EBC14B0F6C55083
-
-      - run: sbt ++${{ matrix.scala }} release
+      - name: Publish
+        run: sbt '++${{ matrix.scala }}' tlRelease

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ ThisBuild / tlBaseVersion := "1.1"
 
 ThisBuild / organization := "org.scala-js"
 ThisBuild / organizationName := "Scala.js (https://www.scala-js.org/)"
-
+ThisBuild / startYear := Some(2021)
 ThisBuild / developers := List(
   Developer("djspiewak", "Daniel Spiewak", "@djspiewak", url("https://github.com/djspiewak")),
   Developer("armanbilge", "Arman Bilge", "@armanbilge", url("https://github.com/armanbilge")))

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("${{ matrix.ci }}")
 
 addCommandAlias("ci", ciVariants.mkString("; ", "; ", ""))
 
-addCommandAlias("ciNode", "; set Global / useJSEnv := JSEnv.NodeJS; test; core/doc; core/mimaReportBinaryIssues")
+addCommandAlias("ciNode", "; set Global / useJSEnv := JSEnv.NodeJS; test; core/doc; core/mimaReportBinaryIssues; headerCheckAll")
 addCommandAlias("ciFirefox", "; set Global / useJSEnv := JSEnv.Firefox; test; set Global / useJSEnv := JSEnv.NodeJS")
 addCommandAlias("ciChrome", "; set Global / useJSEnv := JSEnv.Chrome; test; set Global / useJSEnv := JSEnv.NodeJS")
 addCommandAlias("ciJSDOMNodeJS", "; set Global / useJSEnv := JSEnv.JSDOMNodeJS; test; set Global / useJSEnv := JSEnv.NodeJS")

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("${{ matrix.ci }}")
 
 addCommandAlias("ci", ciVariants.mkString("; ", "; ", ""))
 
-addCommandAlias("ciNode", "; set Global / useJSEnv := JSEnv.NodeJS; test; core/doc")
+addCommandAlias("ciNode", "; set Global / useJSEnv := JSEnv.NodeJS; test; core/doc; core/mimaReportBinaryIssues")
 addCommandAlias("ciFirefox", "; set Global / useJSEnv := JSEnv.Firefox; test; set Global / useJSEnv := JSEnv.NodeJS")
 addCommandAlias("ciChrome", "; set Global / useJSEnv := JSEnv.Chrome; test; set Global / useJSEnv := JSEnv.NodeJS")
 addCommandAlias("ciJSDOMNodeJS", "; set Global / useJSEnv := JSEnv.JSDOMNodeJS; test; set Global / useJSEnv := JSEnv.NodeJS")

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ import org.scalajs.jsenv.selenium.SeleniumJSEnv
 
 import java.util.concurrent.TimeUnit
 
-ThisBuild / baseVersion := "1.1"
+ThisBuild / tlBaseVersion := "1.1"
 
 ThisBuild / organization := "org.scala-js"
 ThisBuild / organizationName := "Scala.js (https://www.scala-js.org/)"
@@ -64,7 +64,7 @@ ThisBuild / githubWorkflowBuildMatrixAdditions += "ci" -> ciVariants
 
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("${{ matrix.ci }}")))
 
-replaceCommandAlias("ci", ciVariants.mkString("; ", "; ", ""))
+addCommandAlias("ci", ciVariants.mkString("; ", "; ", ""))
 
 addCommandAlias("ciNode", "; set Global / useJSEnv := JSEnv.NodeJS; test; core/doc")
 addCommandAlias("ciFirefox", "; set Global / useJSEnv := JSEnv.Firefox; test; set Global / useJSEnv := JSEnv.NodeJS")
@@ -73,24 +73,7 @@ addCommandAlias("ciJSDOMNodeJS", "; set Global / useJSEnv := JSEnv.JSDOMNodeJS; 
 
 // release configuration
 
-enablePlugins(SonatypeCiReleasePlugin)
-
-ThisBuild / spiewakMainBranches := Seq("main")
 ThisBuild / githubWorkflowArtifactUpload := false
-
-// we can remove this once we have a non-password-protected key in the secrets
-ThisBuild / githubWorkflowPublishPreamble := Seq(
-  WorkflowStep.Run(
-    List(
-      "echo \"$PGP_SECRET\" | base64 -d > /tmp/signing-key.gpg",
-      "echo \"$PGP_PASSPHRASE\" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg"),
-    name = Some("Import signing key"),
-    env = Map("PGP_PASSPHRASE" -> "${{ secrets.PGP_PASSPHRASE }}")),
-
-  WorkflowStep.Run(
-    List("(echo \"$PGP_PASSPHRASE\"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase 5EBC14B0F6C55083"),
-    name = Some("Strip passphrase from signing key"),
-    env = Map("PGP_PASSPHRASE" -> "${{ secrets.PGP_PASSPHRASE }}")))
 
 // environments
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0"
 
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.23.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "1.1.1"
 libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0"
 
-addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.23.0")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.12")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")


### PR DESCRIPTION
Migrates the build infrastructure to sbt-typelevel, which was largely derived from sbt-spiewak but has better support for Scala.js projects.

https://typelevel.org/sbt-typelevel/

Fixes https://github.com/scala-js/scala-js-macrotask-executor/issues/33. Fixes https://github.com/scala-js/scala-js-macrotask-executor/issues/43.