### PR TITLE
Ignore Scala and Scala.js updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.ignore = [
+  { groupId = "org.scala-lang" },
+  { groupId = "org.scala-js" }
+]


### PR DESCRIPTION
Closes https://github.com/scala-js/scala-js-macrotask-executor/pull/60.

Hopefully we won't need to release this library again for a long while.